### PR TITLE
Pass own HttpClient instance

### DIFF
--- a/Library/Client.cs
+++ b/Library/Client.cs
@@ -19,11 +19,16 @@ namespace Unsplash
     public sealed class Client : IDisposable
     {
         private const string VERSION = "1";
-        private readonly HttpClient netClient = new HttpClient();
+        private readonly HttpClient netClient;
 
-        public Client(string accessKey)
+        public Client(string accessKey) : this(accessKey, new HttpClient())
+        {
+        }
+
+        public Client(string accessKey, HttpClient client)
         {
             AccessKey = accessKey;
+            netClient = client;
             netClient.DefaultRequestHeaders.Add("Accept-Version", $"v{VERSION}");
         }
 

--- a/Library/Photos/Photo.cs
+++ b/Library/Photos/Photo.cs
@@ -20,7 +20,7 @@ namespace Unsplash.Photos
 
         public uint height { get; set; }
 
-        public URLs urls { get; set; }
+        public DownloadURLs urls { get; set; }
 
         public uint likes { get; set; }
 


### PR DESCRIPTION
Thanks for creating this library.

We'd like to pass our own `HttpClient` instance to make use of `IHttpClientFactory `and custom message handlers.